### PR TITLE
Bump networking/wireguard-tools to 1.0.20210223

### DIFF
--- a/packages/wireguard-tools/definition.yaml
+++ b/packages/wireguard-tools/definition.yaml
@@ -1,6 +1,6 @@
 name: wireguard-tools
 category: networking
-version: 1.0.20200827+1
+version: "1.0.20210914"
 labels:
   github.repo: "wireguard-tools"
   github.owner: "WireGuard"


### PR DESCRIPTION
git-stash: The sock drawer of version control