### PR TITLE
Bump kernel/linux-firmware-ucode to 20210315

### DIFF
--- a/multi-arch/packages/linux-firmware/ucode/definition.yaml
+++ b/multi-arch/packages/linux-firmware/ucode/definition.yaml
@@ -1,11 +1,10 @@
 name: linux-firmware-ucode
 category: kernel
-version: "20210208"
+version: "20210315"
 requires:
-- name: musl
-  category: system
-  version: ">=0"
-
+  - name: musl
+    category: system
+    version: ">=0"
 description: "linux-firmware ucode"
 uri:
   - "https://git.kernel.org/?p=linux/kernel/git/firmware/linux-firmware.git;a=summary"
@@ -19,3 +18,4 @@ labels:
     eval "$(curl -L -s https://git.alpinelinux.org/aports/plain/main/linux-firmware/APKBUILD)" && echo $pkgver
   autobump.version_hook: |
     eval "$(curl -L -s https://git.alpinelinux.org/aports/plain/main/linux-firmware/APKBUILD)" && echo $pkgver
+  package.version: "20210315"


### PR DESCRIPTION
You can checkout any time you like, but you can never diff.