### PR TITLE
Bump editors/vim to 8.2.2847

### DIFF
--- a/multi-arch/packages/vim/definition.yaml
+++ b/multi-arch/packages/vim/definition.yaml
@@ -1,5 +1,5 @@
 name: vim
-version: "8.2.2846"
+version: "8.2.2860"
 category: editors
 requires:
   - name: ncurses


### PR DESCRIPTION
git-fetch: no training required